### PR TITLE
Potential fix for code scanning alert no. 1: Stored cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react": "19.0.0-rc-58af67a8f8-20240628",
     "react-dom": "19.0.0-rc-58af67a8f8-20240628",
     "remark-footnotes": "^5.0.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "he": "^1.2.0"
   },
   "devDependencies": {
     "@types/eslint": "^8.56.10",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 import { MDX } from "./mdx";
 import { getBlogPostBySlug } from "~~/blog";
 import IconSocial from "../../../components/iconSocial";
+import he from "he";
 
 const formatDate = (date: string) => {
   return new Date(date).toLocaleDateString("en-US", {
@@ -71,17 +72,17 @@ export default function Post({ params }: { params: { slug: string } }) {
           __html: JSON.stringify({
             "@context": "https://schema.org",
             "@type": "BlogPosting",
-            headline: post.metadata.title,
-            datePublished: post.metadata.date,
-            dateModified: post.metadata.date,
-            description: post.metadata.description,
-            image: `https://davidadarme.vercel.app/og/blog?title=${post.metadata.title}&top=${formatDate(
-              post.metadata.date,
+            headline: he.encode(post.metadata.title),
+            datePublished: he.encode(post.metadata.date),
+            dateModified: he.encode(post.metadata.date),
+            description: he.encode(post.metadata.description),
+            image: `https://davidadarme.vercel.app/og/blog?title=${he.encode(post.metadata.title)}&top=${he.encode(
+              formatDate(post.metadata.date),
             )}`,
-            url: `https://davidadarme.vercel.app/blog/${post.slug}`,
+            url: `https://davidadarme.vercel.app/blog/${he.encode(post.slug)}`,
             author: {
               "@type": "Person",
-              name: author.name,
+              name: he.encode(author.name),
             },
           }),
         }}


### PR DESCRIPTION
Potential fix for [https://github.com/linustorvaldss/davidadarme.com/security/code-scanning/1](https://github.com/linustorvaldss/davidadarme.com/security/code-scanning/1)

To fix the issue, we need to sanitize or escape the values from `post.metadata` before injecting them into the DOM using `dangerouslySetInnerHTML`. This can be achieved by using a library like `he` (HTML entities) to encode the values, ensuring that any potentially malicious HTML or JavaScript is neutralized.

The changes will involve:
1. Importing the `he` library for HTML encoding.
2. Encoding all user-controlled or file-based values (`post.metadata.title`, `post.metadata.description`, `post.slug`, etc.) before they are included in the JSON object passed to `dangerouslySetInnerHTML`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
